### PR TITLE
Add extra metafields for verification

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: anara
 Type: Package
 Title: Highlight Problems In Survey Data
-Version: 0.0.2
+Version: 0.0.3
 Authors@R:
     c(person(given = "Patrick",
              family = "Anker",

--- a/R/fix-verification.R
+++ b/R/fix-verification.R
@@ -320,7 +320,7 @@ verify_fixes <- function(
     total_fixes <- data.table::rbindlist(list(fix_history, fixes), use.names = TRUE, fill = TRUE)
 
     total_fixes[, previous_modification := vlapply(fixhash, function(x) x %in% reversehash)]
-    total_fixes[previous_modification == TRUE, old_modification := vcapply(fixhash, function(x) {
+    total_fixes[previous_modification == TRUE, old_modification := map_chr(fixhash, function(x) {
       total_fixes[reversehash == x, fixhash]
     })]
 

--- a/R/verify.R
+++ b/R/verify.R
@@ -16,6 +16,9 @@
 #'   to be used for comparison across datasets.
 #' @param extra_metrics A `metrics()` call that contains a collection of
 #'   `metric()` calls
+#' @param extra_cols A character vector of columns to be included in the output
+#'   verification spreadsheet, mainly for reference and support during
+#'   manual inspection
 #' @param verbose Enables logging
 #' @param ... Extra parameters passed to `anara::fix_format`
 #' @return A `data.frame` in the fix format
@@ -29,18 +32,20 @@ verify_ids <- function(
   database_col = "database",
   variables = NULL,
   extra_metrics = NULL,
+  extra_cols = NULL,
   verbose = TRUE,
   ...
 ) {
   stopifnot(is.character(id_col))
   stopifnot(is.character(unique_id_col))
   stopifnot(length(id_col) == 1 && length(unique_id_col) == 1)
+  stopifnot(is.null(extra_cols) || is.character(extra_cols))
 
   validate_dat_list(dat_list)
   validate_control_column(id_col, dat_list, "ID column")
   validate_control_column(unique_id_col, dat_list, "record unique ID column")
 
-  var_pool <- variable_pool(dat_list, variables, extra_metrics)
+  var_pool <- variable_pool(dat_list, c(variables, extra_cols), extra_metrics)
   selected_data <- select_variable_pool(
     dat_list,
     id_col,

--- a/man/verify_ids.Rd
+++ b/man/verify_ids.Rd
@@ -12,6 +12,7 @@ verify_ids(
   database_col = "database",
   variables = NULL,
   extra_metrics = NULL,
+  extra_cols = NULL,
   verbose = TRUE,
   ...
 )
@@ -35,6 +36,10 @@ to be used for comparison across datasets.}
 
 \item{extra_metrics}{A \code{metrics()} call that contains a collection of
 \code{metric()} calls}
+
+\item{extra_cols}{A character vector of columns to be included in the output
+verification spreadsheet, mainly for reference and support during
+manual inspection}
 
 \item{verbose}{Enables logging}
 


### PR DESCRIPTION
Adds `extra_cols` to `anara::verify_ids` to add extra columns which may be useful to inspect during manual verification.