### PR TITLE
Add custom tolerances

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: anara
 Type: Package
 Title: Highlight Problems In Survey Data
-Version: 0.0.4
+Version: 0.0.5
 Authors@R:
     c(person(given = "Patrick",
              family = "Anker",

--- a/R/detect_issues.R
+++ b/R/detect_issues.R
@@ -1,23 +1,23 @@
-detect_issues <- function(x, ...) {
+detect_issues <- function(x, tol, ...) {
   UseMethod("detect_issues", x)
 }
 
 #' @export
-detect_issues.integer <- function(x, abs_distance = 1L, ...) {
+detect_issues.integer <- function(x, tol = 1, ...) {
   mat <- abs(outer(x, x, `-`))
 
-  any(mat[upper.tri(mat)] > abs_distance, na.rm = TRUE)
+  any(mat[upper.tri(mat)] > tol, na.rm = TRUE)
 }
 
 #' @export
-detect_issues.character <- function(x, tolerance = 0.2, ...) {
+detect_issues.character <- function(x, tol = 0.2, ...) {
   x <- stringi::stri_trans_tolower(x)
 
   not_subset_mat <- not_subset_matrix(x)
   sim_mat <- stringdist::stringsimmatrix(x, x)
 
   not_subset_tri <- not_subset_mat[upper.tri(not_subset_mat)]
-  not_sim_tri <- sim_mat[upper.tri(sim_mat)] < (1 - tolerance)
+  not_sim_tri <- sim_mat[upper.tri(sim_mat)] < (1 - tol)
 
   any(not_subset_tri & not_sim_tri, na.rm = TRUE)
 }

--- a/R/verify.R
+++ b/R/verify.R
@@ -14,6 +14,12 @@
 #' @param database_col The column name to store the `dat_list` names
 #' @param variables A character vector of integer or character columns
 #'   to be used for comparison across datasets.
+#' @param tolerances If not `NULL`, a `list` of parameters to be used as tolerances.
+#'   The list names must be variable names provided to `variables`, and the type
+#'   of tolerances depends on the variable:
+#'   * If the variable is an integer, the tolerance is the maximum difference allowed
+#'   * If the variable is a character, the tolerance is maximum dissimilarity allowed,
+#'     measured between 0 and 1.
 #' @param extra_metrics A `metrics()` call that contains a collection of
 #'   `metric()` calls
 #' @param extra_cols A character vector of columns to be included in the output
@@ -22,8 +28,29 @@
 #' @param verbose Enables logging
 #' @param ... Extra parameters passed to `anara::fix_format`
 #' @return A `data.frame` in the fix format
-#' 
 #' @export
+#' 
+#' @examples
+#' if (FALSE) {
+#'   anara::verify_ids(
+#'     list(
+#'       database1 = dat_1,
+#'       database2 = dat_2
+#'     ),
+#'     id_col = "participant_id",
+#'     unique_id_col = "unique_id",
+#'     variables = c("female", "grade", "teacher_name", "form"),
+#'     tolerances = list(
+#'       form = 0,
+#'       teacher_name = 0.05
+#'     ),
+#'     extra_cols = c(
+#'       "start", "end",
+#'       "incdnt_01", "incdnt_01_o", "incdnt_02", "incdnt_02_o"
+#'     ),
+#'     file = file.path("path", "to", "issues.csv")
+#'   )
+#' } 
 verify_ids <- function(
   dat_list,
   id_col,

--- a/R/verify.R
+++ b/R/verify.R
@@ -132,7 +132,7 @@ verify_fields_ <- function(dat, variables, tols, mets, id_col, verbose) {
       }
 
       if (!is.null(tols[[v]])) {
-        dat[, paste0(v, "_issue") := detect_issues(.SD[[v]], tols[[v]]), by = id_col]
+        dat[, paste0(v, "_issue") := detect_issues(.SD[[v]], tol = tols[[v]]), by = id_col]
       } else {
         dat[, paste0(v, "_issue") := detect_issues(.SD[[v]]), by = id_col]
       }

--- a/man/verify_ids.Rd
+++ b/man/verify_ids.Rd
@@ -11,6 +11,7 @@ verify_ids(
   file = NULL,
   database_col = "database",
   variables = NULL,
+  tolerances = NULL,
   extra_metrics = NULL,
   extra_cols = NULL,
   verbose = TRUE,
@@ -34,6 +35,15 @@ will be saved.}
 \item{variables}{A character vector of integer or character columns
 to be used for comparison across datasets.}
 
+\item{tolerances}{If not \code{NULL}, a \code{list} of parameters to be used as tolerances.
+The list names must be variable names provided to \code{variables}, and the type
+of tolerances depends on the variable:
+\itemize{
+\item If the variable is an integer, the tolerance is the maximum difference allowed
+\item If the variable is a character, the tolerance is maximum dissimilarity allowed,
+measured between 0 and 1.
+}}
+
 \item{extra_metrics}{A \code{metrics()} call that contains a collection of
 \code{metric()} calls}
 
@@ -52,4 +62,26 @@ A \code{data.frame} in the fix format
 Compares demographic information across datasets to determine
 if the entity identified with ID \code{x} is the same across all
 datasets.
+}
+\examples{
+if (FALSE) {
+  anara::verify_ids(
+    list(
+      database1 = dat_1,
+      database2 = dat_2
+    ),
+    id_col = "participant_id",
+    unique_id_col = "unique_id",
+    variables = c("female", "grade", "teacher_name", "form"),
+    tolerances = list(
+      form = 0,
+      teacher_name = 0.05
+    ),
+    extra_cols = c(
+      "start", "end",
+      "incdnt_01", "incdnt_01_o", "incdnt_02", "incdnt_02_o"
+    ),
+    file = file.path("path", "to", "issues.csv")
+  )
+} 
 }


### PR DESCRIPTION
Allows users to specify the distances during default variable inspection on character and integer columns.

e.g. from the Peru project:

```r
anara::verify_ids(
  list(
    p3w1g5_form3_ch = p3w1g5_form3_ch,
    p3w1g5_form3_cr = p3w1g5_form3_cr,
    p3w1g5_form7_ch = p3w1g5_form7_ch,
    p3w1g5_form7_cr = p3w1g5_form7_cr
  ),
  id_col = "c_id_01",
  unique_id_col = "unique_id",
  variables = c("cfemale", "cgrade", "cdob_str", "form", "e_id_01"),
  tolerances = list(
    form = 0,
    e_id_01 = 0
  ),
  extra_cols = c(
    "start", "end",
    "incdnt_01", "incdnt_01_o", "incdnt_02", "incdnt_02_o"
  ),
  file = issue_file
)
```